### PR TITLE
[BUG] Wire PaperTradingAccount into integration test framework - closes #86

### DIFF
--- a/app/pt_integration.py
+++ b/app/pt_integration.py
@@ -33,6 +33,7 @@ from pt_paper_trading import (
     OrderType,
     PaperTradingAccount,
 )
+from decimal import Decimal  # noqa: E402
 
 
 @dataclass
@@ -519,8 +520,6 @@ class LiveIntegrationTester:
 
     async def _test_trading_simulation(self):
         """Test trading simulation system using PaperTradingAccount."""
-        from decimal import Decimal
-
         start_time = time.time()
 
         # Test 1: account initialisation
@@ -559,13 +558,13 @@ class LiveIntegrationTester:
                 OrderStatus.PENDING,
                 OrderStatus.REJECTED,
             ):
-                result_status = "PASS" if status == OrderStatus.FILLED else "WARNING"
+                result_status = "PASS" if status == OrderStatus.FILLED else "FAIL"
                 self._add_result(
                     "Trading Simulation",
                     "Place Buy Order",
                     result_status,
                     (time.time() - t2) * 1000,
-                    f"Market BUY 0.001 BTC: order_id={order_id[:8]}, status={status.value}",
+                    f"Market BUY 0.001 BTC: order_id={str(order_id)[:8]}, status={status.value}",
                 )
             else:
                 raise ValueError(f"Unexpected order status: {status}")

--- a/app/pt_integration.py
+++ b/app/pt_integration.py
@@ -27,6 +27,12 @@ from pt_performance import PerformanceMonitor
 # PowerTrader imports
 from pt_risk import RiskLimits, RiskManager
 from pt_validation import InputValidator
+from pt_paper_trading import (
+    OrderSide,
+    OrderStatus,
+    OrderType,
+    PaperTradingAccount,
+)
 
 
 @dataclass
@@ -512,17 +518,91 @@ class LiveIntegrationTester:
         )
 
     async def _test_trading_simulation(self):
-        """Test trading simulation system."""
+        """Test trading simulation system using PaperTradingAccount."""
+        from decimal import Decimal
+
         start_time = time.time()
 
-        # This would test paper trading functionality
-        self._add_result(
-            "Trading Simulation",
-            "Paper Trading",
-            "SKIP",
-            (time.time() - start_time) * 1000,
-            "Paper trading system not yet implemented",
-        )
+        # Test 1: account initialisation
+        try:
+            account = PaperTradingAccount(initial_balance=Decimal("10000"))
+            assert float(account.cash_balance) == 10000.0
+            self._add_result(
+                "Trading Simulation",
+                "Account Init",
+                "PASS",
+                (time.time() - start_time) * 1000,
+                f"PaperTradingAccount initialised: balance=${account.cash_balance}",
+            )
+        except Exception as exc:
+            self._add_result(
+                "Trading Simulation",
+                "Account Init",
+                "FAIL",
+                (time.time() - start_time) * 1000,
+                f"PaperTradingAccount init failed: {exc}",
+            )
+            return
+
+        # Test 2: place market buy order
+        t2 = time.time()
+        try:
+            order_id = account.place_order(
+                symbol="BTC",
+                order_type=OrderType.MARKET,
+                side=OrderSide.BUY,
+                quantity=Decimal("0.001"),
+            )
+            status = account.get_order_status(order_id)
+            if status in (
+                OrderStatus.FILLED,
+                OrderStatus.PENDING,
+                OrderStatus.REJECTED,
+            ):
+                result_status = "PASS" if status == OrderStatus.FILLED else "WARNING"
+                self._add_result(
+                    "Trading Simulation",
+                    "Place Buy Order",
+                    result_status,
+                    (time.time() - t2) * 1000,
+                    f"Market BUY 0.001 BTC: order_id={order_id[:8]}, status={status.value}",
+                )
+            else:
+                raise ValueError(f"Unexpected order status: {status}")
+        except Exception as exc:
+            self._add_result(
+                "Trading Simulation",
+                "Place Buy Order",
+                "FAIL",
+                (time.time() - t2) * 1000,
+                f"Place order failed: {exc}",
+            )
+            return
+
+        # Test 3: account summary reflects the trade
+        t3 = time.time()
+        try:
+            summary = account.get_account_summary()
+            assert "total_value" in summary
+            assert "positions" in summary
+            assert summary["total_trades"] >= 0
+            self._add_result(
+                "Trading Simulation",
+                "Account Summary",
+                "PASS",
+                (time.time() - t3) * 1000,
+                f"Summary OK: total_value=${summary['total_value']:.2f}, "
+                f"trades={summary['total_trades']}",
+                details=summary,
+            )
+        except Exception as exc:
+            self._add_result(
+                "Trading Simulation",
+                "Account Summary",
+                "FAIL",
+                (time.time() - t3) * 1000,
+                f"Account summary failed: {exc}",
+            )
 
     def _add_result(
         self,

--- a/app/pt_integration.py
+++ b/app/pt_integration.py
@@ -13,6 +13,7 @@ import sys
 import time
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
+from decimal import Decimal
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional
 
@@ -33,7 +34,6 @@ from pt_paper_trading import (
     OrderType,
     PaperTradingAccount,
 )
-from decimal import Decimal  # noqa: E402
 
 
 @dataclass
@@ -553,21 +553,22 @@ class LiveIntegrationTester:
                 quantity=Decimal("0.001"),
             )
             status = account.get_order_status(order_id)
-            if status in (
-                OrderStatus.FILLED,
-                OrderStatus.PENDING,
-                OrderStatus.REJECTED,
-            ):
-                result_status = "PASS" if status == OrderStatus.FILLED else "FAIL"
+            if status == OrderStatus.FILLED:
                 self._add_result(
                     "Trading Simulation",
                     "Place Buy Order",
-                    result_status,
+                    "PASS",
                     (time.time() - t2) * 1000,
                     f"Market BUY 0.001 BTC: order_id={str(order_id)[:8]}, status={status.value}",
                 )
             else:
-                raise ValueError(f"Unexpected order status: {status}")
+                self._add_result(
+                    "Trading Simulation",
+                    "Place Buy Order",
+                    "FAIL",
+                    (time.time() - t2) * 1000,
+                    f"Market BUY 0.001 BTC: unexpected status={status.value} (expected FILLED)",
+                )
         except Exception as exc:
             self._add_result(
                 "Trading Simulation",

--- a/app/test_paper_trading_integration.py
+++ b/app/test_paper_trading_integration.py
@@ -1,0 +1,136 @@
+"""
+Tests for PaperTradingAccount wired into pt_integration.py - issue #86.
+Verifies account lifecycle, order placement, and account summary.
+"""
+import unittest
+from decimal import Decimal
+
+from pt_paper_trading import (
+    OrderSide,
+    OrderStatus,
+    OrderType,
+    PaperTradingAccount,
+)
+
+
+class TestPaperTradingIntegration(unittest.TestCase):
+    """Tests confirming PaperTradingAccount works as integration layer expects."""
+
+    def setUp(self):
+        self.account = PaperTradingAccount(initial_balance=Decimal("10000"))
+
+    def test_account_initialises_with_balance(self):
+        self.assertEqual(float(self.account.cash_balance), 10000.0)
+
+    def test_market_buy_fills(self):
+        order_id = self.account.place_order(
+            symbol="BTC",
+            order_type=OrderType.MARKET,
+            side=OrderSide.BUY,
+            quantity=Decimal("0.001"),
+        )
+        status = self.account.get_order_status(order_id)
+        self.assertEqual(status, OrderStatus.FILLED)
+
+    def test_market_buy_reduces_cash(self):
+        self.account.place_order(
+            symbol="BTC",
+            order_type=OrderType.MARKET,
+            side=OrderSide.BUY,
+            quantity=Decimal("0.001"),
+        )
+        self.assertLess(float(self.account.cash_balance), 10000.0)
+
+    def test_buy_creates_position(self):
+        self.account.place_order(
+            symbol="BTC",
+            order_type=OrderType.MARKET,
+            side=OrderSide.BUY,
+            quantity=Decimal("0.001"),
+        )
+        position = self.account.get_position("BTC")
+        self.assertIsNotNone(position)
+        self.assertEqual(float(position.quantity), 0.001)
+
+    def test_account_summary_structure(self):
+        summary = self.account.get_account_summary()
+        required = [
+            "account_id",
+            "cash_balance",
+            "positions_value",
+            "total_value",
+            "unrealized_pnl",
+            "realized_pnl",
+            "total_pnl",
+            "total_trades",
+            "win_rate_pct",
+            "positions",
+        ]
+        for key in required:
+            self.assertIn(key, summary)
+
+    def test_sell_after_buy(self):
+        self.account.place_order(
+            symbol="ETH",
+            order_type=OrderType.MARKET,
+            side=OrderSide.BUY,
+            quantity=Decimal("0.01"),
+        )
+        sell_id = self.account.place_order(
+            symbol="ETH",
+            order_type=OrderType.MARKET,
+            side=OrderSide.SELL,
+            quantity=Decimal("0.01"),
+        )
+        status = self.account.get_order_status(sell_id)
+        self.assertEqual(status, OrderStatus.FILLED)
+        self.assertIsNone(self.account.get_position("ETH"))
+
+    def test_cancel_pending_limit_order(self):
+        from pt_paper_trading import MarketDataSimulator
+
+        price = MarketDataSimulator().get_current_price("BTC") * Decimal("0.5")
+        order_id = self.account.place_order(
+            symbol="BTC",
+            order_type=OrderType.LIMIT,
+            side=OrderSide.BUY,
+            quantity=Decimal("0.001"),
+            price=price,
+        )
+        cancelled = self.account.cancel_order(order_id)
+        self.assertTrue(cancelled)
+        self.assertEqual(self.account.get_order_status(order_id), OrderStatus.CANCELLED)
+
+    def test_oversized_order_rejected(self):
+        """Order exceeding risk limits (10% portfolio) should be rejected."""
+        order_id = self.account.place_order(
+            symbol="BTC",
+            order_type=OrderType.MARKET,
+            side=OrderSide.BUY,
+            quantity=Decimal("10"),  # ~$450k, far exceeds $1000 limit
+        )
+        self.assertEqual(self.account.get_order_status(order_id), OrderStatus.REJECTED)
+
+    def test_integration_method_produces_pass_results(self):
+        """Verify the integration test method produces PASS results, not SKIP."""
+        import asyncio
+
+        # Import integration tester
+        try:
+            from pt_integration import IntegrationTester
+
+            tester = IntegrationTester()
+            asyncio.get_event_loop().run_until_complete(
+                tester._test_trading_simulation()
+            )
+            statuses = [r.status for r in tester.test_results]
+            # Should not have any SKIP results
+            self.assertNotIn("SKIP", statuses)
+            # Should have at least one PASS
+            self.assertIn("PASS", statuses)
+        except ImportError:
+            self.skipTest("IntegrationTester not importable in this environment")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/app/test_paper_trading_integration.py
+++ b/app/test_paper_trading_integration.py
@@ -102,12 +102,19 @@ class TestPaperTradingIntegration(unittest.TestCase):
         self.assertEqual(self.account.get_order_status(order_id), OrderStatus.CANCELLED)
 
     def test_oversized_order_rejected(self):
-        """Order exceeding risk limits (10% portfolio) should be rejected."""
+        """Order exceeding risk limits (>10% of $10k portfolio) should be rejected."""
+        # Derive a quantity that always exceeds 10% of portfolio regardless of price
+        # 10% of $10,000 = $1,000 max; BTC is always > $1k, so 10 BTC always fails
+        from pt_paper_trading import MarketDataSimulator
+
+        btc_price = float(MarketDataSimulator().get_current_price("BTC"))
+        # 5x the portfolio value worth of BTC - always rejected
+        excessive_qty = Decimal(str(round(50000.0 / btc_price, 4)))
         order_id = self.account.place_order(
             symbol="BTC",
             order_type=OrderType.MARKET,
             side=OrderSide.BUY,
-            quantity=Decimal("10"),  # ~$450k, far exceeds $1000 limit
+            quantity=excessive_qty,
         )
         self.assertEqual(self.account.get_order_status(order_id), OrderStatus.REJECTED)
 
@@ -117,12 +124,10 @@ class TestPaperTradingIntegration(unittest.TestCase):
 
         # Import integration tester
         try:
-            from pt_integration import IntegrationTester
+            from pt_integration import LiveIntegrationTester
 
-            tester = IntegrationTester()
-            asyncio.get_event_loop().run_until_complete(
-                tester._test_trading_simulation()
-            )
+            tester = LiveIntegrationTester()
+            asyncio.run(tester._test_trading_simulation())
             statuses = [r.status for r in tester.test_results]
             # Should not have any SKIP results
             self.assertNotIn("SKIP", statuses)

--- a/app/test_paper_trading_integration.py
+++ b/app/test_paper_trading_integration.py
@@ -2,6 +2,7 @@
 Tests for PaperTradingAccount wired into pt_integration.py - issue #86.
 Verifies account lifecycle, order placement, and account summary.
 """
+
 import asyncio
 import os
 import tempfile

--- a/app/test_paper_trading_integration.py
+++ b/app/test_paper_trading_integration.py
@@ -2,10 +2,14 @@
 Tests for PaperTradingAccount wired into pt_integration.py - issue #86.
 Verifies account lifecycle, order placement, and account summary.
 """
+import asyncio
+import os
+import tempfile
 import unittest
 from decimal import Decimal
 
 from pt_paper_trading import (
+    MarketDataSimulator,
     OrderSide,
     OrderStatus,
     OrderType,
@@ -87,8 +91,6 @@ class TestPaperTradingIntegration(unittest.TestCase):
         self.assertIsNone(self.account.get_position("ETH"))
 
     def test_cancel_pending_limit_order(self):
-        from pt_paper_trading import MarketDataSimulator
-
         price = MarketDataSimulator().get_current_price("BTC") * Decimal("0.5")
         order_id = self.account.place_order(
             symbol="BTC",
@@ -102,14 +104,16 @@ class TestPaperTradingIntegration(unittest.TestCase):
         self.assertEqual(self.account.get_order_status(order_id), OrderStatus.CANCELLED)
 
     def test_oversized_order_rejected(self):
-        """Order exceeding risk limits (>10% of $10k portfolio) should be rejected."""
-        # Derive a quantity that always exceeds 10% of portfolio regardless of price
-        # 10% of $10,000 = $1,000 max; BTC is always > $1k, so 10 BTC always fails
-        from pt_paper_trading import MarketDataSimulator
+        """Order exceeding risk limits (>10% of $10k portfolio) should be rejected.
 
-        btc_price = float(MarketDataSimulator().get_current_price("BTC"))
-        # 5x the portfolio value worth of BTC - always rejected
-        excessive_qty = Decimal(str(round(50000.0 / btc_price, 4)))
+        Quantity is derived from the live simulator price so this test remains
+        valid regardless of what price MarketDataSimulator returns.  We request
+        5× the entire portfolio value worth of BTC — always above any reasonable
+        risk limit.
+        """
+        btc_price = MarketDataSimulator().get_current_price("BTC")
+        # 5x portfolio value in BTC, pure Decimal — no float round-trip
+        excessive_qty = (Decimal("50000") / btc_price).quantize(Decimal("0.0001"))
         order_id = self.account.place_order(
             symbol="BTC",
             order_type=OrderType.MARKET,
@@ -119,22 +123,23 @@ class TestPaperTradingIntegration(unittest.TestCase):
         self.assertEqual(self.account.get_order_status(order_id), OrderStatus.REJECTED)
 
     def test_integration_method_produces_pass_results(self):
-        """Verify the integration test method produces PASS results, not SKIP."""
-        import asyncio
+        """Verify _test_trading_simulation produces PASS results, not SKIP.
 
-        # Import integration tester
+        Uses a TemporaryDirectory for config_path so the test is hermetic and
+        creates no files in the working tree.
+        """
         try:
             from pt_integration import LiveIntegrationTester
+        except ImportError:
+            self.skipTest("LiveIntegrationTester not importable in this environment")
 
-            tester = LiveIntegrationTester()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_path = os.path.join(tmpdir, "integration_test.json")
+            tester = LiveIntegrationTester(config_path=config_path)
             asyncio.run(tester._test_trading_simulation())
             statuses = [r.status for r in tester.test_results]
-            # Should not have any SKIP results
             self.assertNotIn("SKIP", statuses)
-            # Should have at least one PASS
             self.assertIn("PASS", statuses)
-        except ImportError:
-            self.skipTest("IntegrationTester not importable in this environment")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Replaces stale `'Paper trading system not yet implemented'` stub in `pt_integration.py:_test_trading_simulation()` with real `PaperTradingAccount` calls
- Three sub-results reported: Account Init, Place Buy Order (0.001 BTC market), Account Summary
- Status SKIP is gone; PASS is reported for each step

## Changes

- **Modified**: `app/pt_integration.py` - `_test_trading_simulation()` + `PaperTradingAccount` import
- **New**: `app/test_paper_trading_integration.py` - 8 tests covering full order lifecycle

## Test plan
- [x] 8 unit tests pass
- [x] Market buy fills (0.001 BTC within risk limits)
- [x] Sell closes position
- [x] Oversized order rejection tested
- [x] Integration method produces PASS not SKIP

Closes #86