### PR TITLE
fix(code-release): remove + from PyPI package name and opt into Node.js 24 runner

### DIFF
--- a/.github/workflows/code-release.yml
+++ b/.github/workflows/code-release.yml
@@ -17,6 +17,7 @@ on:
 
 env:
   PYTHON_VERSION: '3.11'
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   create-release-artifact:
@@ -268,7 +269,7 @@ jobs:
             return ""
 
         setup(
-            name="PowerTraderAI+",
+            name="PowerTraderAI",
             version="${{ steps.version.outputs.PYTHON_VERSION }}",
             author="Simon Jackson",
             author_email="simon@jacksonfamily.me",


### PR DESCRIPTION
## Problem

Two issues identified from CI run [#33](https://github.com/sjackson0109/PowerTraderAI/actions/runs/26047502157/job/76575428334), triggered by the merge of PR #88:

### 1. Build failure - invalid PyPI package name (exit code 1)

The **Create Python package** step failed with:

```
error: Invalid distribution name or version syntax: PowerTraderAI--2026.5.18+c3a2d85
```

Root cause: `name="PowerTraderAI+"` in the inline `setup.py` heredoc. The `+` character is not permitted in distribution names per PEP 508. `setuptools` normalises it to `-`, which then combines with the version separator to produce the double-dash `PowerTraderAI--` string that triggers the error.

**Fix:** rename the package from `"PowerTraderAI+"` to `"PowerTraderAI"` in the `setup()` call.

### 2. Warning - Node.js 20 action deprecation (upcoming hard failure 2 June 2026)

The runner reported:

```
Node.js 20 actions are deprecated. Actions will be forced to run with Node.js 24
by default starting June 2nd, 2026.
Affected: actions/checkout@v4, actions/setup-python@v5
```

**Fix:** add `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` to the workflow `env` block, opting in now before the forced cutover on 2 June 2026.

## Changes

- `.github/workflows/code-release.yml`
  - `name="PowerTraderAI+"` -> `name="PowerTraderAI"` in `setup()` call
  - Added `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` to top-level `env` block