### PR TITLE
fix: left-panel vertical sash, Thinking box height, API server toggle, add missing deps

### DIFF
--- a/app/pt_api_server.py
+++ b/app/pt_api_server.py
@@ -364,24 +364,28 @@ class PowerTraderAPIServer:
             logger.warning("API server is already running")
             return
 
+        # Set the flag BEFORE starting the thread so any immediate stop_server()
+        # or second start_server() call sees the correct state during thread startup.
+        self._is_running = True
+
         def run_server():
             try:
                 logger.info(
                     f"Starting PowerTrader API server on {self.host}:{self.port}"
                 )
                 self._httpd = make_server(self.host, self.port, self.app, threaded=True)
-                self._is_running = True
                 self._httpd.serve_forever()
             except Exception as e:
                 logger.error(f"API server error: {e}")
-            finally:
                 self._is_running = False
+            finally:
                 if self._httpd is not None:
                     try:
                         self._httpd.server_close()
                     except Exception:
                         pass
                 self._httpd = None
+                self._is_running = False
 
         self._server_thread = threading.Thread(target=run_server, daemon=True)
         self._server_thread.start()
@@ -391,13 +395,18 @@ class PowerTraderAPIServer:
 
     def stop_server(self):
         """Stop the API server, releasing the bound socket."""
-        if not self._is_running:
+        # Gate on _httpd rather than _is_running to handle the brief startup
+        # window where the thread is running but _is_running may lag.
+        if self._httpd is None and not self._is_running:
             return
         try:
             if self._httpd is not None:
                 self._httpd.shutdown()
         except Exception as e:
             logger.warning(f"API server shutdown error: {e}")
+        # Wait briefly for the thread to release the socket before returning.
+        if self._server_thread is not None:
+            self._server_thread.join(timeout=3)
         self._is_running = False
         logger.info("API server stopped")
 

--- a/app/pt_api_server.py
+++ b/app/pt_api_server.py
@@ -11,6 +11,7 @@ from datetime import datetime, timedelta
 from typing import Any, Dict, List, Optional
 
 from flask import Flask, jsonify, request
+from werkzeug.serving import make_server
 from flask_cors import CORS
 from pt_logging import get_logger
 
@@ -34,6 +35,7 @@ class PowerTraderAPIServer:
 
         # Server state
         self._server_thread = None
+        self._httpd = None
         self._is_running = False
 
         self._setup_routes()
@@ -367,26 +369,32 @@ class PowerTraderAPIServer:
                 logger.info(
                     f"Starting PowerTrader API server on {self.host}:{self.port}"
                 )
-                self.app.run(host=self.host, port=self.port, debug=False, threaded=True)
+                self._httpd = make_server(self.host, self.port, self.app)
+                self._is_running = True
+                self._httpd.serve_forever()
             except Exception as e:
                 logger.error(f"API server error: {e}")
             finally:
                 self._is_running = False
+                self._httpd = None
 
         self._server_thread = threading.Thread(target=run_server, daemon=True)
         self._server_thread.start()
-        self._is_running = True
-
-        logger.info(f"PowerTrader API server started at http://{self.host}:{self.port}")
+        logger.info(
+            f"PowerTrader API server starting at http://{self.host}:{self.port}"
+        )
 
     def stop_server(self):
-        """Stop the API server."""
+        """Stop the API server, releasing the bound socket."""
         if not self._is_running:
             return
-
-        # Flask doesn't have a clean shutdown method, so we'll just mark as stopped
+        try:
+            if self._httpd is not None:
+                self._httpd.shutdown()
+        except Exception as e:
+            logger.warning(f"API server shutdown error: {e}")
         self._is_running = False
-        logger.info("API server stop requested")
+        logger.info("API server stopped")
 
     def is_running(self) -> bool:
         """Check if the server is running."""

--- a/app/pt_api_server.py
+++ b/app/pt_api_server.py
@@ -369,15 +369,18 @@ class PowerTraderAPIServer:
                 logger.info(
                     f"Starting PowerTrader API server on {self.host}:{self.port}"
                 )
-                self._httpd = make_server(
-                    self.host, self.port, self.app, threaded=True
-                )
+                self._httpd = make_server(self.host, self.port, self.app, threaded=True)
                 self._is_running = True
                 self._httpd.serve_forever()
             except Exception as e:
                 logger.error(f"API server error: {e}")
             finally:
                 self._is_running = False
+                if self._httpd is not None:
+                    try:
+                        self._httpd.server_close()
+                    except Exception:
+                        pass
                 self._httpd = None
 
         self._server_thread = threading.Thread(target=run_server, daemon=True)

--- a/app/pt_api_server.py
+++ b/app/pt_api_server.py
@@ -369,7 +369,9 @@ class PowerTraderAPIServer:
                 logger.info(
                     f"Starting PowerTrader API server on {self.host}:{self.port}"
                 )
-                self._httpd = make_server(self.host, self.port, self.app)
+                self._httpd = make_server(
+                    self.host, self.port, self.app, threaded=True
+                )
                 self._is_running = True
                 self._httpd.serve_forever()
             except Exception as e:

--- a/app/pt_hub.py
+++ b/app/pt_hub.py
@@ -2655,9 +2655,7 @@ class PowerTraderHub(tk.Tk):
         trading_section.grid(row=1, column=1, sticky="nsew", padx=(3, 0), pady=(3, 3))
 
         # Thinking section: row 2, column 0, 2x wide, 1x high
-        neural_section = ttk.LabelFrame(
-            main_container, text="Thinking (Signals)"
-        )
+        neural_section = ttk.LabelFrame(main_container, text="Thinking (Signals)")
         neural_section.grid(row=2, column=0, columnspan=2, sticky="nsew", pady=(6, 0))
 
         # Title row with training counter and buttons

--- a/app/pt_hub.py
+++ b/app/pt_hub.py
@@ -2410,7 +2410,7 @@ class PowerTraderHub(tk.Tk):
             relief="flat",
         )
 
-        m_scripts = tk.Menu(
+        m_file = tk.Menu(
             menubar,
             tearoff=0,
             bg=DARK_BG2,
@@ -2418,15 +2418,8 @@ class PowerTraderHub(tk.Tk):
             activebackground=DARK_SELECT_BG,
             activeforeground=DARK_SELECT_FG,
         )
-        m_scripts.add_command(label="Start All", command=self.start_all_scripts)
-        m_scripts.add_command(label="Stop All", command=self.stop_all_scripts)
-        m_scripts.add_separator()
-        m_scripts.add_command(label="Start Neural Runner", command=self.start_neural)
-        m_scripts.add_command(label="Stop Neural Runner", command=self.stop_neural)
-        m_scripts.add_separator()
-        m_scripts.add_command(label="Start Trader", command=self.start_trader)
-        m_scripts.add_command(label="Stop Trader", command=self.stop_trader)
-        menubar.add_cascade(label="Scripts", menu=m_scripts)
+        m_file.add_command(label="Exit", command=self._on_close)
+        menubar.add_cascade(label="File", menu=m_file)
 
         m_settings = tk.Menu(
             menubar,
@@ -2454,17 +2447,6 @@ class PowerTraderHub(tk.Tk):
         m_help.add_separator()
         m_help.add_command(label="About PowerTrader", command=self.show_about)
         menubar.add_cascade(label="Help", menu=m_help)
-
-        m_file = tk.Menu(
-            menubar,
-            tearoff=0,
-            bg=DARK_BG2,
-            fg=DARK_FG,
-            activebackground=DARK_SELECT_BG,
-            activeforeground=DARK_SELECT_FG,
-        )
-        m_file.add_command(label="Exit", command=self._on_close)
-        menubar.add_cascade(label="File", menu=m_file)
 
         self.config(menu=menubar)
 

--- a/app/pt_hub.py
+++ b/app/pt_hub.py
@@ -2587,8 +2587,8 @@ class PowerTraderHub(tk.Tk):
             1, weight=0, minsize=90
         )  # Training section - compact
         main_container.grid_rowconfigure(
-            2, weight=1, minsize=90
-        )  # Thinking section - grows to fill leftover space
+            2, weight=1, minsize=150
+        )  # Thinking section - grows to fit tile content
         main_container.grid_columnconfigure(
             0, weight=2, minsize=180
         )  # Account column - wider with minimum
@@ -2747,13 +2747,13 @@ class PowerTraderHub(tk.Tk):
 
         # Neural levels display (compact version for the section)
         neural_levels_frame = ttk.Frame(neural_section)
-        neural_levels_frame.pack(fill="x", expand=False, padx=6, pady=(0, 6))
+        neural_levels_frame.pack(fill="both", expand=True, padx=6, pady=(0, 6))
 
         # ttk.Label(neural_levels_frame, text="Neural Levels (0-7):").pack(anchor="w")
 
         # Scrollable area for neural tiles in the neural section
         neural_viewport = ttk.Frame(neural_levels_frame)
-        neural_viewport.pack(fill="x", expand=False, pady=(2, 0))
+        neural_viewport.pack(fill="both", expand=True, pady=(2, 0))
         neural_viewport.grid_rowconfigure(0, weight=1)
         neural_viewport.grid_columnconfigure(0, weight=1)
 
@@ -2763,7 +2763,7 @@ class PowerTraderHub(tk.Tk):
             highlightthickness=1,
             highlightbackground=DARK_BORDER,
             bd=0,
-            height=35,  # Very compact height to eliminate scrollbar
+            height=110,  # Tall enough for one row of NeuralSignalTile (~52px bar + labels)
         )
         self._neural_overview_canvas.grid(row=0, column=0, sticky="nsew")
 
@@ -3040,7 +3040,7 @@ class PowerTraderHub(tk.Tk):
                 if total <= 2:
                     self.after(10, _init_left_split_sash_once)
                     return
-                target = min(380, total - 80)
+                target = min(450, total - 80)
                 left_split.sashpos(0, int(target))
                 self._did_init_left_split_sash = True
             except Exception:

--- a/app/pt_hub.py
+++ b/app/pt_hub.py
@@ -2782,7 +2782,7 @@ class PowerTraderHub(tk.Tk):
             "<Configure>", _on_neural_canvas_configure, add="+"
         )
         self.neural_wrap.bind("<Configure>", _fit_neural_canvas, add="+")
-        self._update_neural_overview_scrollbars = _fit_neural_canvas
+        self._fit_neural_canvas_height = _fit_neural_canvas
 
         # Initialize neural tiles dictionary and cache for this neural section
         self.neural_tiles: Dict[str, NeuralSignalTile] = {}
@@ -2791,7 +2791,7 @@ class PowerTraderHub(tk.Tk):
         # Build the neural tiles
         self._rebuild_neural_overview()
         try:
-            self.after_idle(self._update_neural_overview_scrollbars)
+            self.after_idle(self._fit_neural_canvas_height)
         except Exception:
             pass
 
@@ -6796,7 +6796,7 @@ Platform: {sys.platform}
             pass
 
         try:
-            fn = getattr(self, "_update_neural_overview_scrollbars", None)
+            fn = getattr(self, "_fit_neural_canvas_height", None)
             if callable(fn):
                 self.after_idle(fn)
         except Exception:

--- a/app/pt_hub.py
+++ b/app/pt_hub.py
@@ -2045,9 +2045,8 @@ class PowerTraderHub(tk.Tk):
         # if bool(self.settings.get("auto_start_scripts", False)):
         #     self.start_all_scripts()
 
-        # Auto-start API server if enabled
-        if API_SERVER_AVAILABLE and self.settings.get("api_server_enabled", False):
-            self.toggle_api_server(True)
+        # NOTE: API server auto-start is handled inside _init_api_server() above.
+        # No second toggle here — that would risk a double-bind on the same port.
 
         self.after(250, self._tick)
 

--- a/app/pt_hub.py
+++ b/app/pt_hub.py
@@ -2047,7 +2047,7 @@ class PowerTraderHub(tk.Tk):
 
         # Auto-start API server if enabled
         if API_SERVER_AVAILABLE and self.settings.get("api_server_enabled", False):
-            self.start_api_server()
+            self.toggle_api_server(True)
 
         self.after(250, self._tick)
 
@@ -2486,9 +2486,9 @@ class PowerTraderHub(tk.Tk):
         except Exception:
             pass
 
-        # LEFT: using direct grid layout (no PanedWindow)
-        # left_split = ttk.Panedwindow(left, orient="vertical")
-        # left_split.pack(fill="both", expand=True, padx=8, pady=8)
+        # LEFT: vertical split (Controls on top, Live Output underneath)
+        left_split = ttk.Panedwindow(left, orient="vertical")
+        left_split.pack(fill="both", expand=True, padx=8, pady=8)
 
         # RIGHT: vertical split (Charts on top, Trades+History underneath)
         right_split = ttk.Panedwindow(right, orient="vertical")
@@ -2496,7 +2496,7 @@ class PowerTraderHub(tk.Tk):
 
         # Keep references so we can clamp sash positions later
         self._pw_outer = outer
-        # self._pw_left_split = left_split  # No longer using PanedWindow for left side
+        self._pw_left_split = left_split
         self._pw_right_split = right_split
 
         # Clamp panes when the user releases a sash or the window resizes
@@ -2509,17 +2509,16 @@ class PowerTraderHub(tk.Tk):
             ),
         )
 
-        # left_split bindings removed since using grid layout
-        # left_split.bind(
-        #     "<Configure>", lambda e: self._schedule_paned_clamp(self._pw_left_split)
-        # )
-        # left_split.bind(
-        #     "<ButtonRelease-1>",
-        #     lambda e: (
-        #         setattr(self, "_user_moved_left_split", True),
-        #         self._schedule_paned_clamp(self._pw_left_split),
-        #     ),
-        # )
+        left_split.bind(
+            "<Configure>", lambda e: self._schedule_paned_clamp(self._pw_left_split)
+        )
+        left_split.bind(
+            "<ButtonRelease-1>",
+            lambda e: (
+                setattr(self, "_user_moved_left_split", True),
+                self._schedule_paned_clamp(self._pw_left_split),
+            ),
+        )
 
         right_split.bind(
             "<Configure>", lambda e: self._schedule_paned_clamp(self._pw_right_split)
@@ -2566,7 +2565,7 @@ class PowerTraderHub(tk.Tk):
             "<ButtonRelease-1>",
             lambda e: (
                 self._schedule_paned_clamp(getattr(self, "_pw_outer", None)),
-                # self._schedule_paned_clamp(getattr(self, "_pw_left_split", None)),  # Removed - using grid layout
+                self._schedule_paned_clamp(getattr(self, "_pw_left_split", None)),
                 self._schedule_paned_clamp(getattr(self, "_pw_right_split", None)),
             ),
         )
@@ -2574,7 +2573,7 @@ class PowerTraderHub(tk.Tk):
         # ----------------------------
         # LEFT: 1) Controls / Health (pane)
         # ----------------------------
-        top_controls = ttk.LabelFrame(left, text="Controls / Health")
+        top_controls = ttk.LabelFrame(left_split, text="Controls / Health")
 
         # Create a main container for organized sections
         main_container = ttk.Frame(top_controls)
@@ -2588,8 +2587,8 @@ class PowerTraderHub(tk.Tk):
             1, weight=0, minsize=90
         )  # Training section - compact
         main_container.grid_rowconfigure(
-            2, weight=0, minsize=70
-        )  # Thinking section - compact
+            2, weight=1, minsize=90
+        )  # Thinking section - grows to fill leftover space
         main_container.grid_columnconfigure(
             0, weight=2, minsize=180
         )  # Account column - wider with minimum
@@ -2657,7 +2656,7 @@ class PowerTraderHub(tk.Tk):
 
         # Thinking section: row 2, column 0, 2x wide, 1x high
         neural_section = ttk.LabelFrame(
-            main_container, text="Thinking (Signals)", font=("TkDefaultFont", 7)
+            main_container, text="Thinking (Signals)"
         )
         neural_section.grid(row=2, column=0, columnspan=2, sticky="nsew", pady=(6, 0))
 
@@ -2915,7 +2914,7 @@ class PowerTraderHub(tk.Tk):
         self._live_log_font = _base.copy()
         self._live_log_font.configure(size=8)
 
-        logs_frame = ttk.LabelFrame(left, text="Live Output")
+        logs_frame = ttk.LabelFrame(left_split, text="Live Output")
         self.logs_nb = ttk.Notebook(logs_frame)
         self.logs_nb.pack(fill="both", expand=True, padx=6, pady=6)
 
@@ -3021,32 +3020,33 @@ class PowerTraderHub(tk.Tk):
         self.trader_text.configure(yscrollcommand=trader_scroll.set)
         self.trader_text.pack(side="left", fill="both", expand=True)
         trader_scroll.pack(side="right", fill="y")
-        # Add left panes using grid layout instead of PanedWindow for rowspan control
-        # Configure left container for grid layout
-        left.grid_rowconfigure(
-            0, weight=0, minsize=320
-        )  # Controls section - compact fixed size
-        left.grid_rowconfigure(
-            1, weight=1
-        )  # Live Output section - expands to fill space
-        left.grid_columnconfigure(0, weight=1)
+        # Add left panes to vertical PanedWindow (enables drag sash between Controls and Live Output)
+        left_split.add(top_controls, weight=0)
+        left_split.add(logs_frame, weight=1)
+        try:
+            left_split.paneconfigure(top_controls, minsize=280)
+            left_split.paneconfigure(logs_frame, minsize=80)
+        except Exception:
+            pass
 
-        # Add sections to grid
-        top_controls.grid(row=0, column=0, sticky="nsew", padx=8, pady=(8, 4))
-        logs_frame.grid(row=1, column=0, sticky="nsew", padx=8, pady=(4, 8))
+        def _init_left_split_sash_once():
+            try:
+                if getattr(self, "_did_init_left_split_sash", False):
+                    return
+                if getattr(self, "_user_moved_left_split", False):
+                    self._did_init_left_split_sash = True
+                    return
+                total = left_split.winfo_height()
+                if total <= 2:
+                    self.after(10, _init_left_split_sash_once)
+                    return
+                target = min(380, total - 80)
+                left_split.sashpos(0, int(target))
+                self._did_init_left_split_sash = True
+            except Exception:
+                pass
 
-        # Grid layout configuration (no longer using PanedWindow for left side)
-        # left_split PanedWindow is now only used as a container
-
-        # Left side sash initialization removed since using grid layout
-        # def _init_left_split_sash_once():
-        #     try:
-        #         if getattr(self, "_did_init_left_split_sash", False):
-        #             return
-        #         # ... (left split sash code removed)
-        #     except Exception:
-        #         pass
-        # self.after_idle(_init_left_split_sash_once)
+        self.after_idle(_init_left_split_sash_once)
 
         # ----------------------------
         # RIGHT TOP: Charts (tabs)
@@ -8458,10 +8458,7 @@ Platform: {sys.platform}
 
                 # Restart API server if settings changed
                 if API_SERVER_AVAILABLE:
-                    if api_enabled_var.get():
-                        self.start_api_server()
-                    else:
-                        self.stop_api_server()
+                    self.toggle_api_server(api_enabled_var.get())
 
                 # If new coin(s) were added and their training folder doesn't exist yet,
                 # create the folder and copy neural_trainer.py into it RIGHT AFTER saving settings.

--- a/app/pt_hub.py
+++ b/app/pt_hub.py
@@ -2765,17 +2765,17 @@ class PowerTraderHub(tk.Tk):
         )
         self._neural_overview_canvas.grid(row=0, column=0, sticky="nsew")
 
-        # Remove scrollbar to eliminate mini scrollbar
-        # self._neural_overview_scroll = ttk.Scrollbar(
-        #     neural_viewport,
-        #     orient="vertical",
-        #     command=self._neural_overview_canvas.yview,
-        # )
-        # self._neural_overview_scroll.grid(row=0, column=1, sticky="ns")
+        self._neural_overview_scroll = ttk.Scrollbar(
+            neural_viewport,
+            orient="vertical",
+            command=self._neural_overview_canvas.yview,
+        )
+        self._neural_overview_scroll.grid(row=0, column=1, sticky="ns")
+        self._neural_overview_scroll.grid_remove()  # Hidden by default; shown only if tiles overflow
 
-        # self._neural_overview_canvas.configure(
-        #     yscrollcommand=self._neural_overview_scroll.set
-        # )
+        self._neural_overview_canvas.configure(
+            yscrollcommand=self._neural_overview_scroll.set
+        )
 
         self.neural_wrap = WrapFrame(self._neural_overview_canvas)
         self._neural_overview_window = self._neural_overview_canvas.create_window(
@@ -8456,7 +8456,30 @@ Platform: {sys.platform}
 
                 # Restart API server if settings changed
                 if API_SERVER_AVAILABLE:
-                    self.toggle_api_server(api_enabled_var.get())
+                    # Sync instance fields from newly-saved settings before toggling
+                    _old_host = self._api_server_host
+                    _old_port = self._api_server_port
+                    self._api_server_enabled = bool(
+                        self.settings.get("api_server_enabled", False)
+                    )
+                    self._api_server_host = self.settings.get(
+                        "api_server_host", "127.0.0.1"
+                    )
+                    self._api_server_port = int(
+                        self.settings.get("api_server_port", 8080)
+                    )
+                    # If host/port changed, tear down the old server so _init_api_server
+                    # will recreate it with the correct address on the next toggle.
+                    if (
+                        _old_host != self._api_server_host
+                        or _old_port != self._api_server_port
+                    ) and getattr(self, "_api_server", None):
+                        try:
+                            self._api_server.stop_server()
+                        except Exception:
+                            pass
+                        self._api_server = None
+                    self.toggle_api_server(self._api_server_enabled)
 
                 # If new coin(s) were added and their training folder doesn't exist yet,
                 # create the folder and copy neural_trainer.py into it RIGHT AFTER saving settings.

--- a/app/pt_hub.py
+++ b/app/pt_hub.py
@@ -359,7 +359,7 @@ class NeuralSignalTile(ttk.Frame):
             width=w,
             height=h,
             bg=self._normal_canvas_bg,
-            highlightthickness=1,
+            highlightthickness=2,
             highlightbackground=self._normal_border,
         )
         self.canvas.pack(padx=2, pady=(2, 0))
@@ -438,7 +438,7 @@ class NeuralSignalTile(ttk.Frame):
                 self.canvas.configure(
                     bg=self._normal_canvas_bg,
                     highlightbackground=self._normal_border,
-                    highlightthickness=1,
+                    highlightthickness=2,
                 )
                 self.title_lbl.configure(foreground=self._normal_fg)
                 self.value_lbl.configure(foreground=self._normal_fg)

--- a/app/pt_hub.py
+++ b/app/pt_hub.py
@@ -2587,8 +2587,8 @@ class PowerTraderHub(tk.Tk):
             1, weight=0, minsize=90
         )  # Training section - compact
         main_container.grid_rowconfigure(
-            2, weight=1, minsize=150
-        )  # Thinking section - grows to fit tile content
+            2, weight=0, minsize=0
+        )  # Thinking section - sizes to content exactly
         main_container.grid_columnconfigure(
             0, weight=2, minsize=180
         )  # Account column - wider with minimum
@@ -2745,14 +2745,14 @@ class PowerTraderHub(tk.Tk):
 
         # Neural levels display (compact version for the section)
         neural_levels_frame = ttk.Frame(neural_section)
-        neural_levels_frame.pack(fill="both", expand=True, padx=6, pady=(0, 6))
+        neural_levels_frame.pack(fill="x", padx=6, pady=(0, 6))
 
         # ttk.Label(neural_levels_frame, text="Neural Levels (0-7):").pack(anchor="w")
 
-        # Scrollable area for neural tiles in the neural section
+        # Tile area - no scrollbar; canvas auto-sizes to tile content
         neural_viewport = ttk.Frame(neural_levels_frame)
-        neural_viewport.pack(fill="both", expand=True, pady=(2, 0))
-        neural_viewport.grid_rowconfigure(0, weight=1)
+        neural_viewport.pack(fill="x", pady=(2, 0))
+        neural_viewport.grid_rowconfigure(0, weight=0)
         neural_viewport.grid_columnconfigure(0, weight=1)
 
         self._neural_overview_canvas = tk.Canvas(
@@ -2761,21 +2761,9 @@ class PowerTraderHub(tk.Tk):
             highlightthickness=1,
             highlightbackground=DARK_BORDER,
             bd=0,
-            height=110,  # Tall enough for one row of NeuralSignalTile (~52px bar + labels)
+            height=110,  # Initial value; auto-updated by _fit_neural_canvas
         )
-        self._neural_overview_canvas.grid(row=0, column=0, sticky="nsew")
-
-        self._neural_overview_scroll = ttk.Scrollbar(
-            neural_viewport,
-            orient="vertical",
-            command=self._neural_overview_canvas.yview,
-        )
-        self._neural_overview_scroll.grid(row=0, column=1, sticky="ns")
-        self._neural_overview_scroll.grid_remove()  # Hidden by default; shown only if tiles overflow
-
-        self._neural_overview_canvas.configure(
-            yscrollcommand=self._neural_overview_scroll.set
-        )
+        self._neural_overview_canvas.grid(row=0, column=0, sticky="ew")
 
         self.neural_wrap = WrapFrame(self._neural_overview_canvas)
         self._neural_overview_window = self._neural_overview_canvas.create_window(
@@ -2784,65 +2772,35 @@ class PowerTraderHub(tk.Tk):
             anchor="nw",
         )
 
-        def _update_neural_overview_scrollbars(event=None) -> None:
-            """Update scrollregion + hide/show the scrollbar depending on overflow."""
+        def _fit_neural_canvas(event=None) -> None:
+            """Resize the canvas height to exactly match the tile content — no scrollbar."""
             try:
-                c = self._neural_overview_canvas
-                win = self._neural_overview_window
-
-                c.update_idletasks()
-                bbox = c.bbox(win)
-                if not bbox:
-                    self._neural_overview_scroll.grid_remove()
-                    return
-
-                c.configure(scrollregion=bbox)
-                content_h = int(bbox[3] - bbox[1])
-                view_h = int(c.winfo_height())
-
-                if content_h > (view_h + 1):
-                    self._neural_overview_scroll.grid()
-                else:
-                    self._neural_overview_scroll.grid_remove()
-                    try:
-                        c.yview_moveto(0)
-                    except Exception:
-                        pass
+                self.neural_wrap.update_idletasks()
+                h = self.neural_wrap.winfo_reqheight()
+                if h > 1:
+                    c = self._neural_overview_canvas
+                    c.configure(
+                        height=h,
+                        scrollregion=(0, 0, c.winfo_reqwidth(), h),
+                    )
             except Exception:
                 pass
 
         def _on_neural_canvas_configure(e) -> None:
-            # Keep the inner wrap frame exactly the canvas width so wrapping is correct.
+            # Keep the inner wrap frame exactly the canvas width so tiles wrap correctly.
             try:
                 self._neural_overview_canvas.itemconfigure(
                     self._neural_overview_window, width=int(e.width)
                 )
             except Exception:
                 pass
-            _update_neural_overview_scrollbars()
+            _fit_neural_canvas()
 
         self._neural_overview_canvas.bind(
             "<Configure>", _on_neural_canvas_configure, add="+"
         )
-        self.neural_wrap.bind(
-            "<Configure>", _update_neural_overview_scrollbars, add="+"
-        )
-        self._update_neural_overview_scrollbars = _update_neural_overview_scrollbars
-
-        # Mousewheel scroll inside the tiles area
-        def _wheel(e):
-            try:
-                if self._neural_overview_scroll.winfo_ismapped():
-                    self._neural_overview_canvas.yview_scroll(
-                        int(-1 * (e.delta / 120)), "units"
-                    )
-            except Exception:
-                pass
-
-        self._neural_overview_canvas.bind(
-            "<Enter>", lambda _e: self._neural_overview_canvas.focus_set(), add="+"
-        )
-        self._neural_overview_canvas.bind("<MouseWheel>", _wheel, add="+")
+        self.neural_wrap.bind("<Configure>", _fit_neural_canvas, add="+")
+        self._update_neural_overview_scrollbars = _fit_neural_canvas
 
         # Initialize neural tiles dictionary and cache for this neural section
         self.neural_tiles: Dict[str, NeuralSignalTile] = {}

--- a/app/pt_trader.py
+++ b/app/pt_trader.py
@@ -270,7 +270,7 @@ def _load_credentials_if_needed():
     if not API_KEY or not BASE64_PRIVATE_KEY:
         print(
             "\n[PowerTrader] Robinhood API credentials not found.\n"
-            "Open the GUI and go to Settings → Robinhood API → Setup / Update.\n"
+            "Open the GUI and go to Settings -> Robinhood API -> Setup / Update.\n"
             "That wizard will generate your keypair, tell you where to paste the public key on Robinhood,\n"
             "and will save encrypted credential files so this trader can authenticate securely.\n"
         )

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,6 +23,8 @@ websockets>=11.0.0
 numpy>=1.24.0
 pandas>=2.0.0
 seaborn>=0.12.0
+scipy>=1.11.0
+sqlalchemy>=2.0.0
 
 # Exchange Integration
 ccxt>=4.0.0


### PR DESCRIPTION
## Summary

This PR bundles fixes discovered during local testing:

### 1. Left-panel vertical drag sash
- Replaced the fixed `grid` layout on the left panel with a `ttk.Panedwindow(orient="vertical")`, allowing the **Controls / Health** and **Live Output** sections to be resized up/down by dragging the sash — mirroring the existing horizontal (left/right) and right-side vertical sashes.
- Default sash position: **450 px** from top (capped at `total_height - 80`); minimum 280 px for Controls, 80 px for Live Output.
- Full clamp/binding support added (`_user_moved_left_split`, `_schedule_paned_clamp`, `bind_all` global clamp).

### 2. Thinking (Signals) box height
- Row 2 of `main_container` changed to `weight=0, minsize=0` so the Thinking section sizes exactly to its content (neural tile canvas + labels) with no fixed/dead space — no scrollbar.
- `_fit_neural_canvas_height()` reads `neural_wrap.winfo_reqheight()` on every `<Configure>` event and resizes the canvas to the exact pixel height of the wrapped tiles.

### 3. `AttributeError: '_tkinter.tkapp' object has no attribute 'stop_api_server'`
- Replaced two call sites (`start_api_server()` / `stop_api_server()`) with `toggle_api_server(bool)`.
- Instance fields `self._api_server_enabled`, `self._api_server_host`, and `self._api_server_port` are now synced from the newly-saved settings **before** calling `toggle_api_server`, so host/port changes take effect immediately.
- If host or port changed while the server was running the old server is stopped and cleared so `_init_api_server` will recreate it with the correct address.

### 4. API server real shutdown (`pt_api_server.py`)
- Replaced `Flask.app.run()` + "just flip a flag" `stop_server()` with `werkzeug.serving.make_server()` + `serve_forever()`.
- `stop_server()` now calls `self._httpd.shutdown()`, which actually stops the `serve_forever()` loop and releases the bound socket — preventing "address already in use" on restart.
- `self._httpd` is stored as an instance attribute; set to `None` in the `finally` block.

### 5. Neural tile scrollbar removed; canvas auto-fits
- The scrollbar widget and all references to `self._neural_overview_scroll` have been removed entirely.
- `_fit_neural_canvas_height` (formerly `_update_neural_overview_scrollbars`) auto-resizes the canvas to the wrapped tile height on every `<Configure>` event — pixel-perfect, no dead space.

### 6. Missing dependencies in `requirements.txt`
- Added `scipy>=1.11.0` and `sqlalchemy>=2.0.0` (required by order management and analytics modules; were previously missing, causing warnings on startup).

### 7. `UnicodeEncodeError` in `pt_trader.py` on Windows
- Replaced `→` (U+2192) in a `print()` message with ASCII `->` to fix crash on Windows cp1252 console.

### 8. Hover border no longer shifts tile layout
- `NeuralSignalTile` canvas now always uses `highlightthickness=2`; hover only changes the border colour (`DARK_BORDER` → `DARK_ACCENT2`), so neither the canvas size nor the surrounding labels shift on mouse-over.

### 9. Scripts menu removed; File menu moved first
- Removed the entire `Scripts` menu (Start/Stop All, Start/Stop Neural Runner, Start/Stop Trader) from the menubar.
- Menu order is now: **File → Settings → Help**.

## Files changed
| File | Changes |
|------|---------|
| `app/pt_hub.py` | Sash layout, Thinking height/auto-fit, API toggle fix, scrollbar removal, hover border fix, menu restructure |
| `app/pt_api_server.py` | werkzeug make_server for real socket shutdown |
| `app/pt_trader.py` | Unicode arrow replacement |
| `requirements.txt` | Added scipy, sqlalchemy |